### PR TITLE
Add complete flag to data nodes graph

### DIFF
--- a/docs/endpoints/data.md
+++ b/docs/endpoints/data.md
@@ -259,7 +259,7 @@ Graph data represents a set of nodes and relationships that are associated to th
 Syntax:
 
 ```
-.get_data_nodes_graph(__node_id__ [, _focus_ ] [, _apply_rules_ ])
+.get_data_nodes_graph(__node_id__ [, _focus_ ] [, _apply_rules_ ] [, _complete_ ])
 ```
 
 | Parameters    | Type        | Required | Default Value | Options  |
@@ -267,6 +267,7 @@ Syntax:
 | node_id       | JSON Object | Yes      | N/A           | N/A      |
 | focus         | String      | No       | N/A           | <ul><li>"software-connected"</li><li>"software"</li><li>"infrastructure"</li></ul> |
 | apply_rules   | Boolean     | No       | False         | <ul><li>True</li><li>False</li></ul> |
+| complete      | Boolean     | No       | False         | <ul><li>True</li><li>False</li></ul> |
 
 ## get_data_kinds()
 

--- a/docs/endpoints/topology.md
+++ b/docs/endpoints/topology.md
@@ -27,7 +27,7 @@ Graph data represents a set of nodes and relationships that are associated to th
 Syntax:
 
 ```
-.get_data_nodes_graph(__node_id__ [, _focus_ ] [, _apply_rules_ ])
+.get_data_nodes_graph(__node_id__ [, _focus_ ] [, _apply_rules_ ] [, _complete_ ])
 ```
 
 | Parameters    | Type        | Required | Default Value | Options  |
@@ -35,6 +35,7 @@ Syntax:
 | node_id       | JSON Object | Yes      | N/A           | N/A      |
 | focus         | String      | No       | N/A           | <ul><li>"software-connected"</li><li>"software"</li><li>"infrastructure"</li></ul> |
 | apply_rules   | Boolean     | No       | False         | <ul><li>True</li><li>False</li></ul> |
+| complete      | Boolean     | No       | False         | <ul><li>True</li><li>False</li></ul> |
 
 ## post_topology_nodes()
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,24 @@
+import sys
+import os
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import tideway
+
+
+def test_data_get_data_nodes_graph_sends_complete():
+    data = tideway.data('host', 'token')
+    with patch('tideway.discoRequests.requests.get') as mock_get:
+        mock_get.return_value = None
+        data.get_data_nodes_graph('node', complete=True)
+        params = mock_get.call_args.kwargs['params']
+        assert params['complete'] is True
+
+
+def test_topology_get_data_nodes_graph_sends_complete():
+    topo = tideway.topology('host', 'token')
+    with patch('tideway.discoRequests.requests.get') as mock_get:
+        mock_get.return_value = None
+        topo.get_data_nodes_graph('node', complete=True)
+        params = mock_get.call_args.kwargs['params']
+        assert params['complete'] is True

--- a/tideway/data.py
+++ b/tideway/data.py
@@ -159,11 +159,11 @@ class Data(appliance):
             response = dr.discoRequest(self, "/data/nodes/{}".format(node_id))
         return response
 
-    def get_data_nodes_graph(self, node_id, focus="sofware-connected", apply_rules=True):
+    def get_data_nodes_graph(self, node_id, focus="software-connected", apply_rules=True, complete=False):
         '''Alternate API call for /data/nodes/node_id/graph'''
         self.params['focus'] = focus
         self.params['apply_rules'] = apply_rules
-        self.params['complete'] = False
+        self.params['complete'] = complete
         response = dr.discoRequest(self, "/data/nodes/{}/graph".format(node_id))
         return response
 

--- a/tideway/topology.py
+++ b/tideway/topology.py
@@ -8,7 +8,7 @@ appliance = tideway.main.Appliance
 class Topology(appliance):
     '''Retrieve topology data from the datastore.'''
 
-    def get_data_nodes_graph(self, node_id, focus="sofware-connected", apply_rules=True, complete=False):
+    def get_data_nodes_graph(self, node_id, focus="software-connected", apply_rules=True, complete=False):
         '''Alternate API call for /data/nodes/node_id/graph'''
         self.params['focus'] = focus
         self.params['apply_rules'] = apply_rules


### PR DESCRIPTION
## Summary
- accept `complete` parameter when requesting data node graphs
- document the new parameter in API docs
- test that the parameter is sent in requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846c8adc4748326a40d917a95718b26