### PR TITLE
Fix focus parameter typo

### DIFF
--- a/tideway/data.py
+++ b/tideway/data.py
@@ -159,7 +159,7 @@ class Data(appliance):
             response = dr.discoRequest(self, "/data/nodes/{}".format(node_id))
         return response
 
-    def get_data_nodes_graph(self, node_id, focus="sofware-connected", apply_rules=True):
+    def get_data_nodes_graph(self, node_id, focus="software-connected", apply_rules=True):
         '''Alternate API call for /data/nodes/node_id/graph'''
         self.params['focus'] = focus
         self.params['apply_rules'] = apply_rules
@@ -167,7 +167,7 @@ class Data(appliance):
         response = dr.discoRequest(self, "/data/nodes/{}/graph".format(node_id))
         return response
 
-    def graphNode(self, node_id, focus="sofware-connected", apply_rules=True):
+    def graphNode(self, node_id, focus="software-connected", apply_rules=True):
         '''Graph data represents a set of nodes and relationships that are associated to the given node.'''
         self.params['focus'] = focus
         self.params['apply_rules'] = apply_rules

--- a/tideway/topology.py
+++ b/tideway/topology.py
@@ -8,7 +8,7 @@ appliance = tideway.main.Appliance
 class Topology(appliance):
     '''Retrieve topology data from the datastore.'''
 
-    def get_data_nodes_graph(self, node_id, focus="sofware-connected", apply_rules=True, complete=False):
+    def get_data_nodes_graph(self, node_id, focus="software-connected", apply_rules=True, complete=False):
         '''Alternate API call for /data/nodes/node_id/graph'''
         self.params['focus'] = focus
         self.params['apply_rules'] = apply_rules
@@ -16,7 +16,7 @@ class Topology(appliance):
         response = dr.discoRequest(self, "/data/nodes/{}/graph".format(node_id))
         return response
 
-    def graphNode(self, node_id, focus="sofware-connected", apply_rules=True):
+    def graphNode(self, node_id, focus="software-connected", apply_rules=True):
         '''
             Graph data represents a set of nodes and relationships that are
             associated to the given node.


### PR DESCRIPTION
## Summary
- fix `software-connected` typo in `tideway/data.py` and `tideway/topology.py`

## Testing
- `python -m compileall tideway`

------
https://chatgpt.com/codex/tasks/task_e_6846c718986083269ee7687019cf359b