### PR TITLE
Fix conditional Kerberos request

### DIFF
--- a/tests/test_kerberos.py
+++ b/tests/test_kerberos.py
@@ -1,0 +1,21 @@
+import tideway
+from tideway.kerberos import Kerberos
+
+class DummyResponse:
+    pass
+
+def test_get_vault_kerberos_realm_calls_once(monkeypatch):
+    calls = []
+    def fake_request(self, endpoint):
+        calls.append(endpoint)
+        return DummyResponse()
+
+    monkeypatch.setattr(tideway.discoRequests, "discoRequest", fake_request)
+
+    kb = Kerberos("host", "token")
+    kb.get_vault_kerberos_realm()
+    assert calls == ["/vault/kerberos/realms"]
+
+    calls.clear()
+    kb.get_vault_kerberos_realm("EXAMPLE")
+    assert calls == ["/vault/kerberos/realms/EXAMPLE"]

--- a/tideway/kerberos.py
+++ b/tideway/kerberos.py
@@ -10,7 +10,6 @@ class Kerberos(appliance):
 
     def get_vault_kerberos_realm(self, realm_name=None):
         '''Retrieve all or specific realm.'''
-        req = dr.discoRequest(self, "/vault/kerberos/realms")
         if realm_name:
             req = dr.discoRequest(self, "/vault/kerberos/realms/{}".format(realm_name))
         else:


### PR DESCRIPTION
## Summary
- ensure `get_vault_kerberos_realm` only issues one request
- add regression test verifying single request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dcb5be9c8326ad6479764d6d53ff