### PR TITLE
Remove unused BASELINE import

### DIFF
--- a/tideway/main.py
+++ b/tideway/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from tkinter import BASELINE
 import requests
 from . import discoRequests as dr
 from . import endpoints


### PR DESCRIPTION
## Summary
- tidy up unused import in `tideway/main.py`
- run linting to verify nothing relies on the removed constant

## Testing
- `ruff check .`
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846de94aea08326bb6c00fdd9d9d6e6