### PR TITLE
Fix params leakage between requests

### DIFF
--- a/tests/test_params_reset.py
+++ b/tests/test_params_reset.py
@@ -1,0 +1,23 @@
+import tideway
+from unittest.mock import patch, MagicMock, ANY
+
+
+def test_params_cleared_after_search():
+    tw = tideway.appliance('host', 'token')
+    with patch('tideway.discoRequests.requests.post') as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, ok=True)
+        tw.data().search({'query': 'search'}, offset=1)
+        assert tw.params == {'limit': 100, 'delete': False}
+
+
+def test_params_not_leak_between_calls():
+    tw = tideway.appliance('host', 'token')
+    with patch('tideway.discoRequests.requests.post') as mock_post, \
+         patch('tideway.discoRequests.requests.get') as mock_get:
+        mock_post.return_value = MagicMock(status_code=200, ok=True)
+        mock_get.return_value = MagicMock(status_code=200, ok=True)
+        tw.data().search({'query': 'search'}, offset=2)
+        tw.get('/about')
+        assert mock_get.call_args[1]['params'] == {'limit': 100, 'delete': False}
+        assert tw.params == {'limit': 100, 'delete': False}
+

--- a/tideway/discoRequests.py
+++ b/tideway/discoRequests.py
@@ -11,18 +11,20 @@ def url_and_headers(target,token,api_endpoint,response):
 def discoRequest(appliance, api_endpoint, response="application/json"):
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.get(url, headers=heads, params=appliance.params, verify=appliance.verify)
-    
+    appliance.reset_params()
     return req
 
 def discoPost(appliance, api_endpoint, jsoncode, response="application/json"):
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.post(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req
 
 def filePost(appliance, api_endpoint, file, response="text/html"):
     files = {"file":open(file,'rb')}
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.post(url, files=files, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req
 
 def keytabPost(appliance, api_endpoint, file, username, response="application/json", content_type="multipart/form-data"):
@@ -30,19 +32,23 @@ def keytabPost(appliance, api_endpoint, file, username, response="application/js
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     heads['Content-type']=content_type
     req = requests.post(url, files=form_data, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req
 
 def discoPatch(appliance, api_endpoint, jsoncode, response="application/json"):
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.patch(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req
 
 def discoPut(appliance, api_endpoint, jsoncode, response="application/json"):
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.put(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req
 
 def discoDelete(appliance, api_endpoint, response="application/json"):
     url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
     req = requests.delete(url, headers=heads, params=appliance.params, verify=appliance.verify)
+    appliance.reset_params()
     return req

--- a/tideway/main.py
+++ b/tideway/main.py
@@ -13,38 +13,50 @@ class Appliance:
     def __init__(self, target, token, limit = 100, delete = False, api_version = "1.5", ssl_verify = False):
         self.target = target
         self.token = token
+        self.default_limit = limit
+        self.default_delete = delete
         self.params = {}
-        self.params['limit'] = limit
-        self.params['delete'] = delete
+        self.reset_params()
         self.api_version = api_version
         self.target_url = "https://" + str(target)
         self.api = self.target_url + "/api"
         self.url = self.api + "/v" + self.api_version
         self.verify = ssl_verify
 
+    def reset_params(self):
+        '''Reset request parameters back to default.'''
+        self.params.clear()
+        self.params['limit'] = self.default_limit
+        self.params['delete'] = self.default_delete
+
     def get(self,endpoint):
         '''Request any endpoint.'''
         req = dr.discoRequest(self,endpoint)
+        self.reset_params()
         return req
 
     def post(self,endpoint,body):
         '''Post any endpoint.'''
         req = dr.discoPost(self, endpoint, body)
+        self.reset_params()
         return req
 
     def delete(self,endpoint):
         '''Delete any endpoint.'''
         req = dr.discoDelete(self, endpoint)
+        self.reset_params()
         return req
 
     def patch(self,endpoint,body):
         '''Patch any endpoint.'''
         req = dr.discoPatch(self, endpoint, body)
+        self.reset_params()
         return req
 
     def put(self,endpoint,body):
         '''Update any endpoint.'''
         req = dr.discoPut(self, endpoint, body)
+        self.reset_params()
         return req
 
     def credentials(self):


### PR DESCRIPTION
## Summary
- add `reset_params` helper in Appliance
- call helper after each request
- reset params in wrapper methods
- test that parameters are cleared after requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846dfbc0074832697dff0584ce0cb3e