### PR TITLE
Fix duplicate keytab upload, correct Kerberos path, update API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Simplified Python library for BMC Discovery API Interface that makes use of the 
         "1.2",
         "1.3",
         "1.4",
-        "1.5"
+        "1.14"
     ],
     "component": "REST API",
     "product": "BMC Discovery",

--- a/tideway/discoRequests.py
+++ b/tideway/discoRequests.py
@@ -9,53 +9,48 @@ def url_and_headers(target,token,api_endpoint,response):
     return url, headers
 
 def discoRequest(appliance, api_endpoint, response="application/json"):
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.get(url, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    req = requests.get(url, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req
 
 def discoPost(appliance, api_endpoint, jsoncode, response="application/json"):
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.post(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    req = requests.post(url, json=jsoncode, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req
 
 def filePost(appliance, api_endpoint, file, response="text/html"):
-    files = {"file":open(file,'rb')}
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.post(url, files=files, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    with open(file, 'rb') as f:
+        files = {"file": f}
+        req = requests.post(url, files=files, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req
 
 def keytabPost(appliance, api_endpoint, file, username, response="application/json", content_type="multipart/form-data"):
-    form_data= {"keytab":open(file,'rb'),"username":username}
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    heads['Content-type']=content_type
-    req = requests.post(url, files=form_data, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    heads['Content-type'] = content_type
+    with open(file, 'rb') as f:
+        form_data = {"keytab": f, "username": username}
+        req = requests.post(url, files=form_data, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
-    return req
-
-def keytabPost(appliance, api_endpoint, file, username, response="application/json", content_type="multipart/form-data"):
-    form_data= {"keytab":open(file,'rb'),"username":username}
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    heads['Content-type']=content_type
-    req = requests.post(url, files=form_data, headers=heads, params=appliance.params, verify=appliance.verify)
     return req
 
 def discoPatch(appliance, api_endpoint, jsoncode, response="application/json"):
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.patch(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    req = requests.patch(url, json=jsoncode, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req
 
 def discoPut(appliance, api_endpoint, jsoncode, response="application/json"):
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.put(url, json=jsoncode, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    req = requests.put(url, json=jsoncode, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req
 
 def discoDelete(appliance, api_endpoint, response="application/json"):
-    url, heads = url_and_headers(appliance.url,appliance.token,api_endpoint,response)
-    req = requests.delete(url, headers=heads, params=appliance.params, verify=appliance.verify)
+    url, heads = url_and_headers(appliance.url, appliance.token, api_endpoint, response)
+    req = requests.delete(url, headers=heads, params=appliance.params.copy(), verify=appliance.verify)
     appliance.reset_params()
     return req

--- a/tideway/kerberos.py
+++ b/tideway/kerberos.py
@@ -63,6 +63,6 @@ class Kerberos(appliance):
         return req
 
     def delete_vault_kerberos_ccache(self, realm_name, username):
-        '''Delete a cedential cache file'''
-        req = dr.discoDelete(self, "/vault/kerberos/realms/{}/keytabs/{}".format(realm_name, username))
+        '''Delete a credential cache file'''
+        req = dr.discoDelete(self, "/vault/kerberos/realms/{}/ccaches/{}".format(realm_name, username))
         return req

--- a/tideway/main.py
+++ b/tideway/main.py
@@ -9,7 +9,7 @@ import tideway
 class Appliance:
     '''An appliance instance.'''
 
-    def __init__(self, target, token, limit = 100, delete = False, api_version = "1.5", ssl_verify = False):
+    def __init__(self, target, token, limit = 100, delete = False, api_version = "1.14", ssl_verify = False):
         self.target = target
         self.token = token
         self.default_limit = limit


### PR DESCRIPTION
## Summary
- open files with context managers when uploading
- ensure request parameters are copied before resetting
- remove duplicate `keytabPost` and fix Kerberos ccache deletion
- default to API version 1.14
- update README example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866537adc7c8326bf0b4d889a99866b