### PR TITLE
Add security API module

### DIFF
--- a/docs/endpoints/security.md
+++ b/docs/endpoints/security.md
@@ -1,0 +1,202 @@
+---
+sort: 13
+---
+
+# Security
+
+Initiate a Security object for the instance of Discovery you intend to manage.
+
+Syntax:
+
+```
+tideway.security(__target__, __token__ [, _api_version_ ] [, _ssl_verify_ ])
+```
+
+Initiation:
+
+```python
+>>> import tideway
+>>> tw = tideway.appliance('appliance-hostname','auth-token')
+>>> security = tw.security()
+```
+
+## get_security_ldap
+
+Retrieve the current LDAP configuration.
+
+Syntax:
+
+```
+.get_security_ldap
+```
+
+## put_security_ldap()
+
+Replace the LDAP configuration.
+
+Syntax:
+
+```
+.put_security_ldap(__json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| json | JSON Object | Yes | N/A | N/A |
+
+## patch_security_ldap()
+
+Update the LDAP configuration.
+
+Syntax:
+
+```
+.patch_security_ldap(__json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| json | JSON Object | Yes | N/A | N/A |
+
+## get_security_group()
+
+Retrieve a list of groups or a specific group.
+
+Syntax:
+
+```
+.get_security_group([ _group_name_ ])
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| group_name | String | No | N/A | N/A |
+
+## post_security_group()
+
+Create a security group.
+
+Syntax:
+
+```
+.post_security_group(__json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| json | JSON Object | Yes | N/A | N/A |
+
+## patch_security_group()
+
+Update an existing group.
+
+Syntax:
+
+```
+.patch_security_group(__group_name__, __json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| group_name | String | Yes | N/A | N/A |
+| json | JSON Object | Yes | N/A | N/A |
+
+## delete_security_group()
+
+Delete a group.
+
+Syntax:
+
+```
+.delete_security_group(__group_name__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| group_name | String | Yes | N/A | N/A |
+
+## get_security_permission()
+
+Retrieve permission definitions or a specific permission set.
+
+Syntax:
+
+```
+.get_security_permission([ _permission_ ])
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| permission | String | No | N/A | N/A |
+
+## get_security_user()
+
+Retrieve a list of users or a specific user.
+
+Syntax:
+
+```
+.get_security_user([ _username_ ])
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| username | String | No | N/A | N/A |
+
+## post_security_user()
+
+Create a new user.
+
+Syntax:
+
+```
+.post_security_user(__json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| json | JSON Object | Yes | N/A | N/A |
+
+## patch_security_user()
+
+Update a user.
+
+Syntax:
+
+```
+.patch_security_user(__username__, __json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| username | String | Yes | N/A | N/A |
+| json | JSON Object | Yes | N/A | N/A |
+
+## delete_security_user()
+
+Delete a user.
+
+Syntax:
+
+```
+.delete_security_user(__username__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| username | String | Yes | N/A | N/A |
+
+## post_security_token()
+
+Retrieve an authentication token for a user.
+
+Syntax:
+
+```
+.post_security_token(__json__)
+```
+
+| Parameters | Type | Required | Default Value | Options |
+| ---------- | ---- | :------: | ------------- | ------- |
+| json | JSON Object | Yes | N/A | N/A |
+

--- a/tideway/__init__.py
+++ b/tideway/__init__.py
@@ -10,6 +10,7 @@ from tideway import main, \
                     knowledge, \
                     events, \
                     kerberos, \
+                    security, \
                     models, \
                     taxonomy, \
                     topology
@@ -32,3 +33,4 @@ models = models.Models
 taxonomy = taxonomy.Taxonomy
 topology = topology.Topology
 vault = vault.Vault
+security = security.Security

--- a/tideway/security.py
+++ b/tideway/security.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+import tideway
+
+# Request helpers
+dr = tideway.discoRequests
+appliance = tideway.main.Appliance
+
+class Security(appliance):
+    '''Manage security settings and users.'''
+
+    def get_security_ldap(self):
+        '''Retrieve LDAP configuration.'''
+        return dr.discoRequest(self, "/security/ldap")
+    get_security_ldaps = property(get_security_ldap)
+
+    def put_security_ldap(self, body):
+        '''Replace LDAP configuration.'''
+        return dr.discoPut(self, "/security/ldap", body)
+
+    def patch_security_ldap(self, body):
+        '''Update LDAP configuration.'''
+        return dr.discoPatch(self, "/security/ldap", body)
+
+    def get_security_group(self, group_name=None):
+        '''Retrieve all groups or a specific group.'''
+        if group_name:
+            return dr.discoRequest(self, f"/security/groups/{group_name}")
+        return dr.discoRequest(self, "/security/groups")
+    get_security_groups = property(get_security_group)
+
+    def post_security_group(self, body):
+        '''Create a new group.'''
+        return dr.discoPost(self, "/security/groups", body)
+
+    def patch_security_group(self, group_name, body):
+        '''Update a group.'''
+        return dr.discoPatch(self, f"/security/groups/{group_name}", body)
+
+    def delete_security_group(self, group_name):
+        '''Delete a group.'''
+        return dr.discoDelete(self, f"/security/groups/{group_name}")
+
+    def get_security_permission(self, permission=None):
+        '''Retrieve permissions or a specific permission set.'''
+        if permission:
+            return dr.discoRequest(self, f"/security/permissions/{permission}")
+        return dr.discoRequest(self, "/security/permissions")
+    get_security_permissions = property(get_security_permission)
+
+    def get_security_user(self, username=None):
+        '''Retrieve users or a specific user.'''
+        if username:
+            return dr.discoRequest(self, f"/security/users/{username}")
+        return dr.discoRequest(self, "/security/users")
+    get_security_users = property(get_security_user)
+
+    def post_security_user(self, body):
+        '''Create a new user.'''
+        return dr.discoPost(self, "/security/users", body)
+
+    def patch_security_user(self, username, body):
+        '''Update a user.'''
+        return dr.discoPatch(self, f"/security/users/{username}", body)
+
+    def delete_security_user(self, username):
+        '''Delete a user.'''
+        return dr.discoDelete(self, f"/security/users/{username}")
+
+    def post_security_token(self, body):
+        '''Retrieve an authentication token for a user.'''
+        return dr.discoPost(self, "/security/token", body)


### PR DESCRIPTION
## Summary
- implement `tideway.security.Security`
- export `Security` in `tideway.__init__`
- document new API calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866617547b08326b953a8fd5378ea10