### PR TITLE
Add outpost discovery endpoints

### DIFF
--- a/docs/endpoints/discovery.md
+++ b/docs/endpoints/discovery.md
@@ -50,6 +50,54 @@ Syntax:
 | ------------ | ----------- | :------: | ------------- | --------|
 | json         | JSON Object | Yes      | N/A           | N/A     |
 
+## get_discovery_outpost()
+
+Get a list of all configured Outposts or details for a specific Outpost.
+
+Syntax:
+
+```
+.get_discovery_outpost([ _outpost_id_ ])
+```
+
+| Parameters   | Type   | Required | Default Value | Options |
+| ------------ | ------ | :------: | ------------- | --------|
+| outpost_id   | String | No       | N/A           | N/A     |
+
+## get_discovery_outposts
+
+Get a list of all configured Outposts. See [get_discovery_outpost](#get_discovery_outpost).
+
+Syntax: `.get_discovery_outposts`
+
+## post_discovery_outpost()
+
+Register a new Outpost with the appliance.
+
+Syntax:
+
+```
+.post_discovery_outpost(__json__)
+```
+
+| Parameters   | Type        | Required | Default Value | Options |
+| ------------ | ----------- | :------: | ------------- | --------|
+| json         | JSON Object | Yes      | N/A           | N/A     |
+
+## delete_discovery_outpost()
+
+Delete a configured Outpost.
+
+Syntax:
+
+```
+.delete_discovery_outpost(__outpost_id__)
+```
+
+| Parameters   | Type   | Required | Default Value | Options |
+| ------------ | ------ | :------: | ------------- | --------|
+| outpost_id   | String | Yes      | N/A           | N/A     |
+
 Example:
 
 ```python
@@ -448,3 +496,52 @@ Syntax:
 | ------------ | ----------- | :------: | ------------- | --------|
 | run_id       | String      | Yes      | N/A           | N/A     |
 | json         | JSON Object | Yes      | N/A           | N/A     |
+
+## get_discovery_outpost()
+
+Get a list of all configured Outposts or details for a specific Outpost.
+
+Syntax:
+
+```
+.get_discovery_outpost([ _outpost_id_ ])
+```
+
+| Parameters   | Type   | Required | Default Value | Options |
+| ------------ | ------ | :------: | ------------- | --------|
+| outpost_id   | String | No       | N/A           | N/A     |
+
+## get_discovery_outposts
+
+Get a list of all configured Outposts. See [get_discovery_outpost](#get_discovery_outpost).
+
+Syntax: `.get_discovery_outposts`
+
+## post_discovery_outpost()
+
+Register a new Outpost with the appliance.
+
+Syntax:
+
+```
+.post_discovery_outpost(__json__)
+```
+
+| Parameters   | Type        | Required | Default Value | Options |
+| ------------ | ----------- | :------: | ------------- | --------|
+| json         | JSON Object | Yes      | N/A           | N/A     |
+
+## delete_discovery_outpost()
+
+Delete a configured Outpost.
+
+Syntax:
+
+```
+.delete_discovery_outpost(__outpost_id__)
+```
+
+| Parameters   | Type   | Required | Default Value | Options |
+| ------------ | ------ | :------: | ------------- | --------|
+| outpost_id   | String | Yes      | N/A           | N/A     |
+

--- a/tests/test_discovery_outposts.py
+++ b/tests/test_discovery_outposts.py
@@ -1,0 +1,54 @@
+import tideway
+from tideway.discovery import Discovery
+
+class DummyResponse:
+    def __init__(self, data=None):
+        self._data = data or {}
+    def json(self):
+        return self._data
+
+
+def test_get_discovery_outpost_endpoint(monkeypatch):
+    calls = []
+    def fake_request(self, endpoint):
+        calls.append(endpoint)
+        return DummyResponse({"id": "all"})
+    monkeypatch.setattr(tideway.discoRequests, "discoRequest", fake_request)
+
+    d = Discovery("host", "token")
+    resp = d.get_discovery_outpost()
+    assert calls == ["/discovery/outposts"]
+    assert resp.json()["id"] == "all"
+
+    calls.clear()
+    resp = d.get_discovery_outpost("abc")
+    assert calls == ["/discovery/outposts/abc"]
+
+
+def test_post_discovery_outpost(monkeypatch):
+    called = {}
+    def fake_post(self, endpoint, body):
+        called["endpoint"] = endpoint
+        called["body"] = body
+        return DummyResponse({"created": True})
+    monkeypatch.setattr(tideway.discoRequests, "discoPost", fake_post)
+
+    d = Discovery("host", "token")
+    body = {"name": "op"}
+    resp = d.post_discovery_outpost(body)
+    assert called["endpoint"] == "/discovery/outposts"
+    assert called["body"] == body
+    assert resp.json()["created"] is True
+
+
+def test_delete_discovery_outpost(monkeypatch):
+    calls = []
+    def fake_delete(self, endpoint):
+        calls.append(endpoint)
+        return DummyResponse({"deleted": True})
+    monkeypatch.setattr(tideway.discoRequests, "discoDelete", fake_delete)
+
+    d = Discovery("host", "token")
+    resp = d.delete_discovery_outpost("xyz")
+    assert calls == ["/discovery/outposts/xyz"]
+    assert resp.json()["deleted"] is True

--- a/tideway/discovery.py
+++ b/tideway/discovery.py
@@ -188,3 +188,22 @@ class Discovery(appliance):
         '''Update the parameters of a specific scheduled discovery run.'''
         response = dr.discoPatch(self, "/discovery/runs/scheduled/{}".format(run_id), body)
         return response
+
+    def get_discovery_outpost(self, outpost_id=None):
+        '''Get all configured Outposts or a specific one.'''
+        if outpost_id:
+            req = dr.discoRequest(self, "/discovery/outposts/{}".format(outpost_id))
+        else:
+            req = dr.discoRequest(self, "/discovery/outposts")
+        return req
+    get_discovery_outposts = property(get_discovery_outpost)
+
+    def post_discovery_outpost(self, body):
+        '''Register a new Outpost.'''
+        response = dr.discoPost(self, "/discovery/outposts", body)
+        return response
+
+    def delete_discovery_outpost(self, outpost_id):
+        '''Delete an Outpost.'''
+        response = dr.discoDelete(self, "/discovery/outposts/{}".format(outpost_id))
+        return response


### PR DESCRIPTION
## Summary
- implement get/add/delete functions for `/discovery/outposts`
- document the new methods
- test new operations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686667896f5c8326888127fab545b3e0