### PR TITLE
Add additional data endpoints

### DIFF
--- a/docs/endpoints/data.md
+++ b/docs/endpoints/data.md
@@ -153,6 +153,16 @@ Syntax:
 | ------------- | ----------- | :------: | ------------- | -------- |
 | body          | JSON Object | Yes      | N/A           | N/A      |
 
+## get_data_condition_params()
+
+Retrieve the list of available condition parameters.
+
+Syntax:
+
+```
+.get_data_condition_params
+```
+
 ## get_data_condition_template()
 
 
@@ -297,6 +307,26 @@ Example: Gets result #50 from list of nodes
 ['0x7761771a5876f667606e53426', 'Apache Webserver', 'Apache Webserver 2.4 on batman3', '2.4', 'batman3']
 ```
 
+## get_data_kinds_values()
+
+Retrieve values for an attribute of a node kind.
+
+Syntax:
+
+```
+.get_data_kinds_values(__kind__, __attribute__ [, _offset_ ] [, _results_id_ ] [, _format_ ] [, _limit_ ] [, _delete_ ])
+```
+
+| Parameters    | Type        | Required | Default Value | Options  |
+| ------------- | ----------- | :------: | ------------- | -------- |
+| kind          | String      | Yes      | N/A           | Any node kind |
+| attribute     | String      | Yes      | N/A           | N/A |
+| offset        | Integer     | No       | N/A           | N/A |
+| results_id    | String      | No       | N/A           | N/A |
+| format        | String      | No       | N/A           | "object" |
+| limit         | Integer     | No       | 100           | N/A |
+| delete        | Boolean     | No       | False         | <ul><li>True</li><li>False</li></ul> |
+
 ## get_data_partitions
 
 Graph data represents a set of nodes and relationships that are associated to the given node.
@@ -375,7 +405,22 @@ Imports data. Returns the import UUID.
 Syntax:
 
 ```
+
 .post_data_import(__json__)
+```
+
+| Parameters    | Type        | Required | Default Value | Options  |
+| ------------- | ----------- | :------: | ------------- | -------- |
+| json          | JSON Object | Yes      | N/A           | N/A      |
+
+## post_data_import_graph()
+
+Import graph data. Returns the import UUID.
+
+Syntax:
+
+```
+.post_data_import_graph(__json__)
 ```
 
 | Parameters    | Type        | Required | Default Value | Options  |
@@ -395,6 +440,68 @@ Syntax:
 | Parameters    | Type        | Required | Default Value | Options  |
 | ------------- | ----------- | :------: | ------------- | -------- |
 | json          | JSON Object | Yes      | N/A           | N/A      |
+
+## get_data_external_consumer()
+
+Retrieve external consumer information. With no arguments all consumers are returned.
+
+Syntax:
+
+```
+.get_data_external_consumer([ _consumer_name_ ] [, _path_ ])
+```
+
+| Parameters    | Type   | Required | Default Value | Options |
+| ------------- | ------ | :------: | ------------- | ------- |
+| consumer_name | String | No       | N/A           | N/A     |
+| path          | String | No       | N/A           | N/A     |
+
+## post_data_external_consumer()
+
+Create or interact with an external consumer resource.
+
+Syntax:
+
+```
+.post_data_external_consumer(__json__ [, _consumer_name_ ] [, _path_ ])
+```
+
+| Parameters    | Type        | Required | Default Value | Options |
+| ------------- | ----------- | :------: | ------------- | ------- |
+| json          | JSON Object | Yes      | N/A           | N/A     |
+| consumer_name | String      | No       | N/A           | N/A     |
+| path          | String      | No       | N/A           | N/A     |
+
+## patch_data_external_consumer()
+
+Update an external consumer resource.
+
+Syntax:
+
+```
+.patch_data_external_consumer(__consumer_name__, __json__ [, _path_ ])
+```
+
+| Parameters    | Type        | Required | Default Value | Options |
+| ------------- | ----------- | :------: | ------------- | ------- |
+| consumer_name | String      | Yes      | N/A           | N/A     |
+| json          | JSON Object | Yes      | N/A           | N/A     |
+| path          | String      | No       | N/A           | N/A     |
+
+## delete_data_external_consumer()
+
+Delete an external consumer resource.
+
+Syntax:
+
+```
+.delete_data_external_consumer(__consumer_name__ [, _path_ ])
+```
+
+| Parameters    | Type   | Required | Default Value | Options |
+| ------------- | ------ | :------: | ------------- | ------- |
+| consumer_name | String | Yes      | N/A           | N/A     |
+| path          | String | No       | N/A           | N/A     |
 
 ## best_candidate()
 

--- a/tests/test_params_reset.py
+++ b/tests/test_params_reset.py
@@ -21,3 +21,12 @@ def test_params_not_leak_between_calls():
         assert mock_get.call_args[1]['params'] == {'limit': 100, 'delete': False}
         assert tw.params == {'limit': 100, 'delete': False}
 
+
+def test_params_reset_after_get_data_kinds_values():
+    tw = tideway.appliance('host', 'token')
+    with patch('tideway.discoRequests.requests.get') as mock_get:
+        mock_get.return_value = MagicMock(status_code=200, ok=True)
+        tw.data().get_data_kinds_values('Host', 'name', offset=5)
+        assert mock_get.call_args[1]['params']['offset'] == 5
+        assert tw.params == {'limit': 100, 'delete': False}
+

--- a/tideway/data.py
+++ b/tideway/data.py
@@ -228,3 +228,61 @@ class Data(appliance):
         '''
         response = dr.discoPost(self, "/data/write", body)
         return response
+
+    def get_data_condition_params(self):
+        '''Retrieve the list of available condition parameters.'''
+        response = dr.discoRequest(self, "/data/condition/params")
+        return response
+
+    def post_data_import_graph(self, body):
+        '''Import graph data and return the import UUID.'''
+        response = dr.discoPost(self, "/data/import/graph", body)
+        return response
+
+    def get_data_external_consumer(self, consumer_name=None, path=None):
+        '''Retrieve external consumer information.'''
+        endpoint = "/data/external_consumers"
+        if consumer_name:
+            endpoint += f"/{consumer_name}"
+            if path:
+                endpoint += f"/{path}"
+        response = dr.discoRequest(self, endpoint)
+        return response
+    get_data_external_consumers = property(get_data_external_consumer)
+
+    def post_data_external_consumer(self, body, consumer_name=None, path=None):
+        '''Create or interact with an external consumer resource.'''
+        endpoint = "/data/external_consumers"
+        if consumer_name:
+            endpoint += f"/{consumer_name}"
+            if path:
+                endpoint += f"/{path}"
+        response = dr.discoPost(self, endpoint, body)
+        return response
+
+    def patch_data_external_consumer(self, consumer_name, body, path=None):
+        '''Update an external consumer resource.'''
+        endpoint = f"/data/external_consumers/{consumer_name}"
+        if path:
+            endpoint += f"/{path}"
+        response = dr.discoPatch(self, endpoint, body)
+        return response
+
+    def delete_data_external_consumer(self, consumer_name, path=None):
+        '''Delete an external consumer resource.'''
+        endpoint = f"/data/external_consumers/{consumer_name}"
+        if path:
+            endpoint += f"/{path}"
+        response = dr.discoDelete(self, endpoint)
+        return response
+
+    def get_data_kinds_values(self, kind, attribute, offset=None, results_id=None, format=None, limit=100, delete=False):
+        '''Retrieve values for an attribute of a node kind.'''
+        self.params['offset'] = offset
+        self.params['results_id'] = results_id
+        self.params['format'] = format
+        self.params['limit'] = limit
+        self.params['delete'] = delete
+        endpoint = f"/data/kinds/{kind}/values/{attribute}"
+        response = dr.discoRequest(self, endpoint)
+        return response

--- a/tideway/endpoints.py
+++ b/tideway/endpoints.py
@@ -198,6 +198,12 @@ docTable = [
                     ],
                 [
                     "GET",
+                    "/data/condition/params",
+                    "- get_data_condition_params()",
+                    "Get the list of available condition parameters.",
+                    ],
+                [
+                    "GET",
                     "/data/condition/templates",
                     "- get_data_condition_templates\n- get_data_condition_template()",
                     "Get a list of all templates."
@@ -264,6 +270,12 @@ docTable = [
                     ],
                 [
                     "GET",
+                    "/data/kinds/{kind}/values/{attribute}",
+                    "- get_data_kinds_values(kind, attribute)",
+                    "Retrieve values for an attribute of a node kind.",
+                    ],
+                [
+                    "GET",
                     "/data/partitions",
                     "- partitions()\n- get_data_partitions",
                     "Get names and ids of partitions."
@@ -282,9 +294,69 @@ docTable = [
                     ],
                 [
                     "POST",
+                    "/data/import/graph",
+                    "- post_data_import_graph(body)",
+                    "Import graph data. Returns the import UUID.",
+                    ],
+                [
+                    "POST",
                     "/data/write",
                     "- twWrite(body)\n- post_data_write(body)",
                     "Perform arbitrary write operations."
+                    ],
+                [
+                    "GET",
+                    "/data/external_consumers",
+                    "- get_data_external_consumers\n- get_data_external_consumer()",
+                    "Retrieve external consumers.",
+                    ],
+                [
+                    "POST",
+                    "/data/external_consumers",
+                    "- post_data_external_consumer(body)",
+                    "Create an external consumer.",
+                    ],
+                [
+                    "GET",
+                    "/data/external_consumers/{consumer}",
+                    "- get_data_external_consumer(consumer)",
+                    "Retrieve an external consumer.",
+                    ],
+                [
+                    "PATCH",
+                    "/data/external_consumers/{consumer}",
+                    "- patch_data_external_consumer(consumer, body)",
+                    "Update an external consumer.",
+                    ],
+                [
+                    "DELETE",
+                    "/data/external_consumers/{consumer}",
+                    "- delete_data_external_consumer(consumer)",
+                    "Delete an external consumer.",
+                    ],
+                [
+                    "GET",
+                    "/data/external_consumers/{consumer}/{path}",
+                    "- get_data_external_consumer(consumer, path)",
+                    "Retrieve external consumer sub-resource.",
+                    ],
+                [
+                    "POST",
+                    "/data/external_consumers/{consumer}/{path}",
+                    "- post_data_external_consumer(body, consumer, path)",
+                    "Create or update external consumer sub-resource.",
+                    ],
+                [
+                    "PATCH",
+                    "/data/external_consumers/{consumer}/{path}",
+                    "- patch_data_external_consumer(consumer, body, path)",
+                    "Update external consumer sub-resource.",
+                    ],
+                [
+                    "DELETE",
+                    "/data/external_consumers/{consumer}/{path}",
+                    "- delete_data_external_consumer(consumer, path)",
+                    "Delete external consumer sub-resource.",
                     ],
                 [
                     "GET",


### PR DESCRIPTION
## Summary
- expose condition params endpoint
- support importing graph data
- add external consumer helpers
- get attribute values for a kind
- document new endpoints
- test params reset on new method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686679e7bc4c832690b7ae649a6d8dd8