### PR TITLE
Add knowledge trigger patterns API

### DIFF
--- a/docs/endpoints/knowledge.md
+++ b/docs/endpoints/knowledge.md
@@ -92,6 +92,20 @@ Example:
 True
 ```
 
+## get_knowledge_trigger_patterns()
+
+Get a list of trigger patterns.
+
+Syntax:
+
+```
+.get_knowledge_trigger_patterns([ _lookup_data_sources_ ])
+```
+
+| Parameters          | Type    | Required | Default Value | Options                          |
+| ------------------- | ------- | :------: | ------------- | -------------------------------- |
+| lookup_data_sources | Boolean | No       | N/A           | <ul><li>True</li><li>False</li></ul> |
+
 ## getKnowledgeManagement()
 
 [Deprecated] See [get_knowledge](#get_knowledge) for usage.

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,12 @@
+import tideway
+from unittest.mock import patch
+
+
+def test_get_knowledge_trigger_patterns_sends_lookup_param():
+    k = tideway.knowledge('host', 'token')
+    with patch('tideway.discoRequests.requests.get') as mock_get:
+        mock_get.return_value = None
+        k.getKnowledgeTriggerPatterns(lookup_data_sources=True)
+        params = mock_get.call_args.kwargs['params']
+        assert params['lookup_data_sources'] is True
+

--- a/tideway/knowledge.py
+++ b/tideway/knowledge.py
@@ -33,3 +33,10 @@ class Knowledge(appliance):
         self.params['allow_restart'] = allow_restart
         response = dr.filePost(self, "/knowledge/{}".format(filename), file)
         return response
+
+    def getKnowledgeTriggerPatterns(self, lookup_data_sources=None):
+        '''Get a list of all knowledge trigger patterns.'''
+        self.params['lookup_data_sources'] = lookup_data_sources
+        response = dr.discoRequest(self, "/knowledge/trigger_patterns")
+        return response
+    get_knowledge_trigger_patterns = property(getKnowledgeTriggerPatterns)


### PR DESCRIPTION
## Summary
- expose `lookup_data_sources` for `GET /knowledge/trigger_patterns`
- document the new method
- test parameter forwarding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667c30089483269e899fee148345d3