### PR TITLE
Add API schema path lookup helper

### DIFF
--- a/tests/test_api_paths.py
+++ b/tests/test_api_paths.py
@@ -1,0 +1,25 @@
+import tideway
+from tideway.main import Appliance
+
+class DummyResponse:
+    def __init__(self, data, status_code=200):
+        self._data = data
+        self.status_code = status_code
+        self.ok = status_code < 400
+    def json(self):
+        return self._data
+
+
+def test_api_paths_lookup(monkeypatch):
+    schema = {"paths": {"/about": {"get": {"summary": "About"}}}}
+
+    def fake_get(url, verify=False):
+        return DummyResponse(schema)
+
+    monkeypatch.setattr(tideway.main.requests, "get", fake_get)
+
+    tw = Appliance("host", "token")
+    paths = tw.api_paths()
+    assert "/about" in paths
+    assert tw.api_paths("/about") == {"get": {"summary": "About"}}
+    assert tw.api_paths("/missing") is None

--- a/tideway/main.py
+++ b/tideway/main.py
@@ -131,6 +131,24 @@ class Appliance:
         '''Fetch API schema, trying /swagger.json first, then /openapi.json.'''
         return self._get_api_schema()
 
+    def _load_schema(self):
+        '''Return cached API schema as dict, fetching it if necessary.'''
+        if getattr(self, '_api_schema', None) is None:
+            response = self.api_swagger
+            self._api_schema = response.json() if response.ok else {}
+        return self._api_schema
+
+    def api_schema(self):
+        '''Return the parsed API schema.'''
+        return self._load_schema()
+
+    def api_paths(self, path=None):
+        '''Return all available API paths or details for a specific path.'''
+        paths = self._load_schema().get('paths', {})
+        if path:
+            return paths.get(path)
+        return paths
+
     @property
     def get_admin_baseline(self):
         '''Alternate API call for baseline.'''


### PR DESCRIPTION
## Summary
- implement `api_schema`/`api_paths` in `Appliance`
- add test for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667df43d8c8326a0742215c033cd4c