### PR TITLE
Refactor duplicate methods

### DIFF
--- a/tideway/data.py
+++ b/tideway/data.py
@@ -54,7 +54,10 @@ class Data(appliance):
 
     def searchQuery(self, body, offset=None, results_id=None, format=None, limit = 100, delete = False):
         '''An alternative to GET /data/search, for search queries which are too long for urls.'''
-        warnings.warn('JSON search body can be used with the search() function.', DeprecationWarning)
+        warnings.warn(
+            "searchQuery() is deprecated; use search() instead.",
+            DeprecationWarning,
+        )
         return Data.search(self, body, offset, results_id, format, limit, delete)
 
     def search_bulk(self, query, format = None, limit = 100, delete = False):
@@ -121,8 +124,11 @@ class Data(appliance):
         '''
             The node object of the best candidate based on the provided parameters.
         '''
-        response = dr.discoPost(self, "/data/candidate", body)
-        return response
+        warnings.warn(
+            "best_candidate() is deprecated; use post_data_candidate() instead.",
+            DeprecationWarning,
+        )
+        return self.post_data_candidate(body)
 
     def post_data_candidates(self, body):
         '''Alternate API call for POST /data/candidates.'''
@@ -134,8 +140,11 @@ class Data(appliance):
             Enter parameters to identify a device, the response is a list of
             candidate nodes ordered by descending score.
         '''
-        response = dr.discoPost(self, "/data/candidates", body)
-        return response
+        warnings.warn(
+            "top_candidates() is deprecated; use post_data_candidates() instead.",
+            DeprecationWarning,
+        )
+        return self.post_data_candidates(body)
 
     def get_data_nodes(self, node_id, relationships=False, traverse=None, flags=None, attributes=None):
         '''Alternate API call for /data/nodes/node_id'''
@@ -150,14 +159,17 @@ class Data(appliance):
 
     def nodeLookup(self, node_id, relationships=False, traverse=None, flags=None, attributes=None):
         '''Get the state of a node with specified id.'''
-        self.params['traverse'] = traverse
-        self.params['flags'] = flags
-        self.params['attributes'] = attributes
-        if relationships:
-            response = dr.discoRequest(self, "/data/nodes/{}?relationships=true".format(node_id))
-        else:
-            response = dr.discoRequest(self, "/data/nodes/{}".format(node_id))
-        return response
+        warnings.warn(
+            "nodeLookup() is deprecated; use get_data_nodes() instead.",
+            DeprecationWarning,
+        )
+        return self.get_data_nodes(
+            node_id,
+            relationships=relationships,
+            traverse=traverse,
+            flags=flags,
+            attributes=attributes,
+        )
 
     def get_data_nodes_graph(self, node_id, focus="software-connected", apply_rules=True, complete=False):
         '''Alternate API call for /data/nodes/node_id/graph'''
@@ -169,10 +181,16 @@ class Data(appliance):
 
     def graphNode(self, node_id, focus="software-connected", apply_rules=True):
         '''Graph data represents a set of nodes and relationships that are associated to the given node.'''
-        self.params['focus'] = focus
-        self.params['apply_rules'] = apply_rules
-        response = dr.discoRequest(self, "/data/nodes/{}/graph".format(node_id))
-        return response
+        warnings.warn(
+            "graphNode() is deprecated; use get_data_nodes_graph() instead.",
+            DeprecationWarning,
+        )
+        return self.get_data_nodes_graph(
+            node_id,
+            focus=focus,
+            apply_rules=apply_rules,
+            complete=False,
+        )
 
     def get_data_kinds(self, kind, offset=None, results_id=None, format=None, limit = 100, delete = False):
         '''Alternate API call for /data/kinds.'''
@@ -186,13 +204,18 @@ class Data(appliance):
 
     def lookupNodeKind(self, kind, offset=None, results_id=None, format=None, limit = 100, delete = False):
         '''Finds all nodes of a specified node kind.'''
-        self.params['offset'] = offset
-        self.params['results_id'] = results_id
-        self.params['format'] = format
-        self.params['limit'] = limit
-        self.params['delete'] = delete
-        response = dr.discoRequest(self, "/data/kinds/{}".format(kind))
-        return response
+        warnings.warn(
+            "lookupNodeKind() is deprecated; use get_data_kinds() instead.",
+            DeprecationWarning,
+        )
+        return self.get_data_kinds(
+            kind,
+            offset=offset,
+            results_id=results_id,
+            format=format,
+            limit=limit,
+            delete=delete,
+        )
 
     def partitions(self):
         '''Get names and ids of partitions.'''
@@ -214,8 +237,11 @@ class Data(appliance):
         '''
             Imports data. Returns the import UUID.
         '''
-        response = dr.discoPost(self, "/data/import", body)
-        return response
+        warnings.warn(
+            "twImport() is deprecated; use post_data_import() instead.",
+            DeprecationWarning,
+        )
+        return self.post_data_import(body)
 
     def post_data_write(self, body):
         '''Alternate API call for /data/write.'''
@@ -226,8 +252,11 @@ class Data(appliance):
         '''
             Perform arbitrary write operations.
         '''
-        response = dr.discoPost(self, "/data/write", body)
-        return response
+        warnings.warn(
+            "twWrite() is deprecated; use post_data_write() instead.",
+            DeprecationWarning,
+        )
+        return self.post_data_write(body)
 
     def get_data_condition_params(self):
         '''Retrieve the list of available condition parameters.'''

--- a/tideway/events.py
+++ b/tideway/events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import tideway
+import warnings
 
 dr = tideway.discoRequests
 appliance = tideway.main.Appliance
@@ -18,5 +19,8 @@ class Events(appliance):
             Returns a unique ID if the event has been recorded, otherwise an
             empty string is returned e.g. if the event source has been disabled.
         '''
-        response = dr.discoPost(self, "/events", body)
-        return response
+        warnings.warn(
+            "status() is deprecated; use post_events() instead.",
+            DeprecationWarning,
+        )
+        return self.post_events(body)

--- a/tideway/knowledge.py
+++ b/tideway/knowledge.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import tideway
+import warnings
 
 dr = tideway.discoRequests
 appliance = tideway.main.Appliance
@@ -8,17 +9,32 @@ appliance = tideway.main.Appliance
 class Knowledge(appliance):
     '''Upload new TKUs and pattern modules.'''
 
+    def get_knowledge(self):
+        '''Get the current state of the appliance's knowledge, including TKU versions.'''
+        return dr.discoRequest(self, "/knowledge")
+
     def getKnowledgeManagement(self):
         '''Get the current state of the appliance's knowledge, including TKU versions.'''
-        response = dr.discoRequest(self, "/knowledge")
-        return response
-    get_knowledge = property(getKnowledgeManagement)
+        warnings.warn(
+            "getKnowledgeManagement() is deprecated; use get_knowledge() instead.",
+            DeprecationWarning,
+        )
+        return self.get_knowledge()
+    get_knowledge_property = property(get_knowledge)
 
     def getUploadStatus(self):
         '''Get the current state of a knowledge upload.'''
-        response = dr.discoRequest(self, "/knowledge/status")
-        return response
-    get_knowledge_status = property(getUploadStatus)
+        warnings.warn(
+            "getUploadStatus() is deprecated; use get_knowledge_status() instead.",
+            DeprecationWarning,
+        )
+        return self.get_knowledge_status()
+
+    def get_knowledge_status(self):
+        '''Get the current state of a knowledge upload.'''
+        return dr.discoRequest(self, "/knowledge/status")
+
+    get_knowledge_status_property = property(get_knowledge_status)
 
     def post_knowledge(self, filename, file, activate=True, allow_restart=False):
         '''Alternate API call for POST /knowledge/filename'''
@@ -29,10 +45,11 @@ class Knowledge(appliance):
 
     def uploadKnowledge(self, filename, file, activate=True, allow_restart=False):
         '''Upload a TKU or pattern module to the appliance.'''
-        self.params['activate'] = activate
-        self.params['allow_restart'] = allow_restart
-        response = dr.filePost(self, "/knowledge/{}".format(filename), file)
-        return response
+        warnings.warn(
+            "uploadKnowledge() is deprecated; use post_knowledge() instead.",
+            DeprecationWarning,
+        )
+        return self.post_knowledge(filename, file, activate, allow_restart)
 
     def getKnowledgeTriggerPatterns(self, lookup_data_sources=None):
         '''Get a list of all knowledge trigger patterns.'''

--- a/tideway/main.py
+++ b/tideway/main.py
@@ -5,6 +5,7 @@ import requests
 from . import discoRequests as dr
 from . import endpoints
 import tideway
+import warnings
 
 class Appliance:
     '''An appliance instance.'''
@@ -109,9 +110,11 @@ class Appliance:
 
     def about(self):
         '''Return about data.'''
-        url = self.api + "/about"
-        req = requests.get(url, verify=self.verify)
-        return req
+        warnings.warn(
+            "about() is deprecated; use api_about instead.",
+            DeprecationWarning,
+        )
+        return self.api_about
 
     def _get_api_schema(self):
         '''Helper to fetch API schema, trying /swagger.json first, then /openapi.json.'''
@@ -129,7 +132,11 @@ class Appliance:
 
     def swagger(self):
         '''Fetch API schema, trying /swagger.json first, then /openapi.json.'''
-        return self._get_api_schema()
+        warnings.warn(
+            "swagger() is deprecated; use api_swagger instead.",
+            DeprecationWarning,
+        )
+        return self.api_swagger
 
     @property
     def get_admin_baseline(self):
@@ -139,8 +146,11 @@ class Appliance:
 
     def baseline(self):
         '''Get a summary of the appliance status, and details of which baseline checks have passed or failed.'''
-        response = dr.discoRequest(self, "/admin/baseline")
-        return response
+        warnings.warn(
+            "baseline() is deprecated; use get_admin_baseline instead.",
+            DeprecationWarning,
+        )
+        return self.get_admin_baseline
 
     @property
     def get_admin_about(self):
@@ -150,8 +160,11 @@ class Appliance:
 
     def admin(self):
         '''Get information about the appliance, like its version and versions of the installed packages.'''
-        response = dr.discoRequest(self, "/admin/about")
-        return response
+        warnings.warn(
+            "admin() is deprecated; use get_admin_about instead.",
+            DeprecationWarning,
+        )
+        return self.get_admin_about
 
     @property
     def get_admin_licensing(self):

--- a/tideway/topology.py
+++ b/tideway/topology.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import tideway
+import warnings
 
 dr = tideway.discoRequests
 appliance = tideway.main.Appliance
@@ -21,10 +22,16 @@ class Topology(appliance):
             Graph data represents a set of nodes and relationships that are
             associated to the given node.
         '''
-        self.params['focus'] = focus
-        self.params['apply_rules'] = apply_rules
-        response = dr.discoRequest(self, "/data/nodes/{}/graph".format(node_id))
-        return response
+        warnings.warn(
+            "graphNode() is deprecated; use get_data_nodes_graph() instead.",
+            DeprecationWarning,
+        )
+        return self.get_data_nodes_graph(
+            node_id,
+            focus=focus,
+            apply_rules=apply_rules,
+            complete=False,
+        )
 
     def post_topology_nodes(self, body):
         '''Alternate API call for POST /topology/nodes.'''
@@ -33,8 +40,11 @@ class Topology(appliance):
 
     def getNodes(self, body):
         '''Get topology data from one or more starting nodes.'''
-        response = dr.discoPost(self, "/topology/nodes", body)
-        return response
+        warnings.warn(
+            "getNodes() is deprecated; use post_topology_nodes() instead.",
+            DeprecationWarning,
+        )
+        return self.post_topology_nodes(body)
 
     def post_topology_nodes_kinds(self, body):
         '''Alternate API call for POST /topology/nodes/kinds.'''
@@ -46,16 +56,22 @@ class Topology(appliance):
             Get nodes of the specified kinds which are related to a given set of
             nodes.
         '''
-        response = dr.discoPost(self, "/topology/nodes/kinds", body)
-        return response
+        warnings.warn(
+            "getNodeKinds() is deprecated; use post_topology_nodes_kinds() instead.",
+            DeprecationWarning,
+        )
+        return self.post_topology_nodes_kinds(body)
 
     def visualizationState(self):
         '''
             Get the current state of the visualization for the authenticated
             user.
         '''
-        response = dr.discoRequest(self, "/topology/visualization_state")
-        return response
+        warnings.warn(
+            "visualizationState() is deprecated; use get_topology_viz_state instead.",
+            DeprecationWarning,
+        )
+        return dr.discoRequest(self, "/topology/visualization_state")
     get_topology_viz_state = property(visualizationState)
 
     def patch_topology_viz_state(self, body):
@@ -68,8 +84,11 @@ class Topology(appliance):
             Update one or more attributes of the current state of the
             visualization for the authenticated user.
         '''
-        response = dr.discoPatch(self, "/topology/visualization_state", body)
-        return response
+        warnings.warn(
+            "updateVizState() is deprecated; use patch_topology_viz_state() instead.",
+            DeprecationWarning,
+        )
+        return self.patch_topology_viz_state(body)
 
     def put_topology_viz_state(self, body):
         '''Alternate API call for PUT /topology/visualization_state'''
@@ -81,5 +100,8 @@ class Topology(appliance):
             Update any or all of the attributes of the current state of the
             visualization for the authenticated user.
         '''
-        response = dr.discoPut(self, "/topology/visualization_state", body)
-        return response
+        warnings.warn(
+            "replaceVizState() is deprecated; use put_topology_viz_state() instead.",
+            DeprecationWarning,
+        )
+        return self.put_topology_viz_state(body)

--- a/tideway/vault.py
+++ b/tideway/vault.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import tideway
+import warnings
 
 dr = tideway.discoRequests
 appliance = tideway.main.Appliance
@@ -8,11 +9,18 @@ appliance = tideway.main.Appliance
 class Vault(appliance):
     '''Manage the credential vault.'''
 
+    def get_vault(self):
+        '''Get details of the state of the vault.'''
+        return dr.discoRequest(self, "/vault")
+
     def getVault(self):
         '''Get details of the state of the vault.'''
-        response = dr.discoRequest(self, "/vault")
-        return response
-    get_vault = property(getVault)
+        warnings.warn(
+            "getVault() is deprecated; use get_vault() instead.",
+            DeprecationWarning,
+        )
+        return self.get_vault()
+    get_vault_property = property(get_vault)
 
     def patch_vault(self, body):
         '''Alternate API call for PATCH /vault'''
@@ -21,5 +29,8 @@ class Vault(appliance):
 
     def updateVault(self, body):
         '''Change the state of the vault.'''
-        response = dr.discoPatch(self, "/vault", body)
-        return response
+        warnings.warn(
+            "updateVault() is deprecated; use patch_vault() instead.",
+            DeprecationWarning,
+        )
+        return self.patch_vault(body)


### PR DESCRIPTION
## Summary
- add DeprecationWarning wrappers around legacy API helpers
- consolidate duplicate logic across Data, Topology, Knowledge, Vault, Events and Appliance

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686683b83c5883269db6d0ae9d1b6856